### PR TITLE
Add a user purge feature

### DIFF
--- a/app/Http/Controllers/Adm/UsersController.php
+++ b/app/Http/Controllers/Adm/UsersController.php
@@ -98,6 +98,48 @@ class UsersController extends BaseController
 
     /**
      * @param \Coyote\User $user
+     * @return \Illuminate\View\View
+     */
+    public function judge($user)
+    {
+        $this->breadcrumb->push("Sąd ostateczny nad " . $user->name, route('adm.users.judge', [$user->id]));
+
+        $form = $this->createForm(AdminForm::class, $user, [
+            'url' => route('adm.users.judge', [$user->id])
+        ]);
+
+        return $this->view('adm.users.purge', [
+            'user' => $user,
+            'form' => $form,
+        ]);
+    }
+
+    /**
+     * @param \Coyote\User $user
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function purge($user)
+    {
+        $form = $this->getForm($user);
+
+        $this->transaction(function () use ($user, $form) {
+            $user->hasMany('Coyote\Post')->delete();
+            $user->permissions()->delete();
+            $user->actkey()->delete();
+            $user->skills()->delete();
+            $user->invoices()->delete();
+            $user->notifications()->delete();
+            $user->relations()->delete();
+            $user->followers()->delete();
+            $user->notificationSettings()->delete();
+            $user->delete();
+        });
+
+        return back()->with('success', 'Zmiany zostały poprawie zapisane');
+    }
+
+    /**
+     * @param \Coyote\User $user
      * @return \Coyote\Services\FormBuilder\Form
      */
     protected function getForm($user)

--- a/app/Http/Grids/Adm/FirewallGrid.php
+++ b/app/Http/Grids/Adm/FirewallGrid.php
@@ -12,6 +12,8 @@ use Coyote\Services\Grid\Grid;
 use Boduch\Grid\Decorators\Ip;
 use Boduch\Grid\Order;
 use Boduch\Grid\Components\EditButton;
+use Coyote\Services\Grid\Components\PurgeButton;
+
 
 class FirewallGrid extends Grid
 {
@@ -58,6 +60,9 @@ class FirewallGrid extends Grid
                     return link_to_route('adm.users.save', $row->moderator_name, [$row->moderator_id]);
                 }
             ])
+            ->addRowAction(new PurgeButton(function (Firewall $row) {
+                return route('adm.users.judge', [$row->user_id]);
+            }))
             ->addRowAction(new EditButton(function (Firewall $row) {
                 return route('adm.firewall.save', [$row->id]);
             }))

--- a/app/Services/Grid/Components/PurgeButton.php
+++ b/app/Services/Grid/Components/PurgeButton.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Coyote\Services\Grid\Components;
+
+use Boduch\Grid\Components\RowAction;
+
+class PurgeButton extends RowAction
+{
+    /**
+     * @return string
+     */
+    public function render()
+    {
+        return (string) $this->tag(
+            'a',
+            (string) $this->tag('i', '', ['class' => 'fa fa-fw fa-fire']),
+            ['href' => $this->buildActionUrl($this->data), 'class' => 'btn btn-default btn-xs', 'title' => 'Usuń tego użytkownika z powierzchni ziemi']
+        );
+    }
+}

--- a/resources/views/adm/users/purge.twig
+++ b/resources/views/adm/users/purge.twig
@@ -1,0 +1,18 @@
+{% extends 'adm.base' %}
+{% block title %}Sąd ostateczny :: {{ user.name }} :: {{ parent() }}{% endblock %}
+
+{% block container %}
+    {{ form_start(form) }}
+
+    <div class="alert alert-danger" role="alert">
+    Czy jesteś <b>ABSOLUTNIE</b> przekonany że chcesz usunąc tego użytkownika
+    razem z wszystkimi jego dokonaniami? Tej operacji <b>nie da się cofnąć</b>.
+    </div>
+
+    <div id="settings" class="card-body tab-pane active">
+        {{ form_row(form.submit) }}
+    </div>
+
+    {{ form_end(form) }}
+
+{% endblock %}

--- a/routes/adm.php
+++ b/routes/adm.php
@@ -71,6 +71,8 @@ $this->group(
         $this->get('Users', 'UsersController@index')->name('users');
         $this->get('Users/Save/{user_trashed}', 'UsersController@edit')->name('users.save');
         $this->post('Users/Save/{user_trashed}', 'UsersController@save');
+        $this->get('Users/Purge/{user}', 'UsersController@judge')->name('users.judge');
+        $this->post('Users/Purge/{user}', 'UsersController@purge');
 
         $this->get('Firewall', 'FirewallController@index')->name('firewall');
         $this->get('Firewall/Save/{firewall?}', 'FirewallController@edit')->name('firewall.save');


### PR DESCRIPTION
My WIP "user purge" feature. Can be used to completely remove an user and all their work. UI (beautiful, I know):

![image](https://user-images.githubusercontent.com/7026881/215913762-4c8a02c4-947c-46e5-9ea8-cec85e9ab595.png)

I don't have a time to finish this, but I promise I'll get around to this soon.

TODO left:

- [ ] change the purge workflow to checkboxes (unchecked by default). They could look like this:

![image](https://user-images.githubusercontent.com/7026881/215913699-87ad4937-ff10-4a30-a6ed-c2f1aaa30278.png)

- [ ] make the admin confirm the deletion by re-typing the username
- [ ] clean up the code, etc

Fixes #463